### PR TITLE
Enforce CancellationToken in ActionBase and Derived Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,9 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking Changes
 
-- **ActionBase Class Update**: Actions extending from `ActionBase` must now pass a `CancellationToken` parameter. The `Run` method in `ActionBase` requires a `CancellationToken` parameter without a default value.
+- **ActionBase Class Update**: Actions extending from `ActionBase` must now pass a `CancellationToken` parameter. The `Run` method in `ActionBase` requires a `CancellationToken`.
 This ensures that all derived classes handle cancellation requests properly, improving resource management and responsiveness.
-Make sure to update all derived classes to include the `CancellationToken` parameter in their `Run` method implementations. This change may break existing implementations that don't currently handle `CancellationToken`.
-
+Make sure to update all derived classes to include the `CancellationToken` parameter in their `Run` method implementations. 
 ## [5.0.4]
 - Refactoring code, big time
 - Upgraded dependencies to latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ All notable changes to this project will be documented in this file.
 - RulesEngine Execute... Methods using params marked obsolete in favor of CancellationToken supported methods
 - original project is no longer being maintained
 
+### Breaking Changes
+
+- **ActionBase Class Update**: Actions extending from `ActionBase` must now pass a `CancellationToken` parameter. The `Run` method in `ActionBase` requires a `CancellationToken` parameter without a default value.
+This ensures that all derived classes handle cancellation requests properly, improving resource management and responsiveness.
+Make sure to update all derived classes to include the `CancellationToken` parameter in their `Run` method implementations. This change may break existing implementations that don't currently handle `CancellationToken`.
+
 ## [5.0.4]
 - Refactoring code, big time
 - Upgraded dependencies to latest

--- a/RulesEngine/Interfaces/IRulesEngine.cs
+++ b/RulesEngine/Interfaces/IRulesEngine.cs
@@ -13,9 +13,9 @@ namespace RulesEngine.Interfaces
     public interface IRulesEngine
     {
         IAsyncEnumerable<List<RuleResultTree>> ExecuteAllWorkflows(RuleParameter[] inputs, CancellationToken ct = default);
-        Task<List<RuleResultTree>> ExecuteWorkflow(string workflow_name, RuleParameter[] inputs, CancellationToken ct = default);
-        Task<RuleResultTree> ExecuteRule(string workflow_name, string rule_name, RuleParameter[] ruleParams, CancellationToken ct = default);
-        Task<ActionRuleResult> ExecuteRuleActions(string workflow_name, string rule_name, RuleParameter[] inputs, CancellationToken ct = default);
+        Task<List<RuleResultTree>> ExecuteWorkflow(string workflowName, RuleParameter[] inputs, CancellationToken ct = default);
+        Task<RuleResultTree> ExecuteRule(string workflowName, string ruleName, RuleParameter[] ruleParams, CancellationToken ct = default);
+        Task<ActionRuleResult> ExecuteRuleActions(string workflowName, string ruleName, RuleParameter[] inputs, CancellationToken ct = default);
 
         #region Obsolete Methods
 

--- a/RulesEngine/RulesEngine.cs
+++ b/RulesEngine/RulesEngine.cs
@@ -74,34 +74,34 @@ namespace RulesEngine
                     yield return await ExecuteWorkflow(wf_nam, inputs, ct);
             }
         }
-        public async Task<List<RuleResultTree>> ExecuteWorkflow(string workflow_name, RuleParameter[] inputs, CancellationToken ct = default)
+        public async Task<List<RuleResultTree>> ExecuteWorkflow(string workflowName, RuleParameter[] inputs, CancellationToken ct = default)
         {
             Array.Sort(inputs, (RuleParameter a, RuleParameter b) => string.Compare(a.Name, b.Name));
 
             var result = new List<RuleResultTree>();
 
-            foreach (var rule in _rulesCache.GetWorkflow(workflow_name).Rules)
+            foreach (var rule in _rulesCache.GetWorkflow(workflowName).Rules)
             {
                 if (ct.IsCancellationRequested)
                     break;
 
-                var resultTree = await ExecuteRule(workflow_name, rule.RuleName, inputs, ct);
+                var resultTree = await ExecuteRule(workflowName, rule.RuleName, inputs, ct);
                 result.Add(resultTree);
             }
             
             return result;
         }
-        public async Task<RuleResultTree> ExecuteRule(string workflow_name, string rule_name, RuleParameter[] ruleParams, CancellationToken ct = default)
+        public async Task<RuleResultTree> ExecuteRule(string workflowName, string ruleName, RuleParameter[] ruleParams, CancellationToken ct = default)
         {
             RuleResultTree ruleResultTree = null;
 
             if (!ct.IsCancellationRequested)
             {
-                if (RegisterRule(workflow_name, ruleParams))
+                if (RegisterRule(workflowName, ruleParams))
                 {
-                    var compiledRulesCacheKey = GetCompiledRulesKey(workflow_name, ruleParams);
+                    var compiledRulesCacheKey = GetCompiledRulesKey(workflowName, ruleParams);
 
-                    var compiledRule = _rulesCache.GetCompiledRules(compiledRulesCacheKey)[rule_name];
+                    var compiledRule = _rulesCache.GetCompiledRules(compiledRulesCacheKey)[ruleName];
                     ruleResultTree = compiledRule(ruleParams);
 
                     FormatErrorMessages(ruleResultTree);
@@ -119,15 +119,15 @@ namespace RulesEngine
                 else
                 {
                     // if rules are not registered with Rules Engine
-                    throw new ArgumentException($"Rule config file is not present for the {workflow_name} workflow");
+                    throw new ArgumentException($"Rule config file is not present for the {workflowName} workflow");
                 }
             }
 
             return ruleResultTree;
         }
-        public async Task<ActionRuleResult> ExecuteRuleActions(string workflow_name, string rule_name, RuleParameter[] inputs, CancellationToken ct = default)
+        public async Task<ActionRuleResult> ExecuteRuleActions(string workflowName, string ruleName, RuleParameter[] inputs, CancellationToken ct = default)
         {
-            var compiledRule = CompileRule(workflow_name, rule_name, inputs);
+            var compiledRule = CompileRule(workflowName, ruleName, inputs);
             var resultTree = compiledRule(inputs);
 
             return await ExecuteActionForRuleResult(resultTree, true, ct);

--- a/docs/index.md
+++ b/docs/index.md
@@ -473,7 +473,7 @@ RulesEngine allows registering custom actions which can be used in the rules wor
             ....
         }
 
-        public override ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters)
+        public override ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters, CancellationToken ct = default)
         {
             var customInput = context.GetContext<string>("customContextInput");
             //Add your custom logic here and return a ValueTask
@@ -489,7 +489,7 @@ Actions can have async code as well
             ....
         }
 
-        public override async ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters)
+        public override async ValueTask<object> Run(ActionContext context, RuleParameter[] ruleParameters, CancellationToken ct = default)
         {
             var customInput = context.GetContext<string>("customContextInput");
             //Add your custom logic here


### PR DESCRIPTION
**Description**:
This pull request introduces a breaking change to the `ActionBase` class, requiring all derived classes to pass a `CancellationToken` parameter. The `Run` method in `ActionBase` now mandates a `CancellationToken` parameter.

**Changes**:
- Updated `ActionBase` class to require a `CancellationToken` in the `Run` method.
- Update the documentation to reflect the `ActionBase` class

**Impact**:
- All derived classes must be updated to include the `CancellationToken` parameter in their `Run` method implementations.

**Action Required**:
- Review and update all derived classes to comply with the new method signature.
- Test the changes to ensure proper handling of `CancellationToken` in all relevant actions.