### PR TITLE
Add Unit Tests for Cancellation Token Handling in ExecuteAllRulesAsync and ExecuteActionWorkflowAsync

### DIFF
--- a/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
+++ b/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
@@ -30,6 +30,9 @@
     <None Update="TestData\rules11.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\rules12.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\rules4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/RulesEngine.UnitTest/TestData/rules12.json
+++ b/test/RulesEngine.UnitTest/TestData/rules12.json
@@ -1,0 +1,32 @@
+{
+  "WorkflowName": "inputWorkflow",
+  "Rules": [
+    {
+      "RuleName": "OneEqualsOneRule",
+      "ErrorMessage": "One or more adjust rules failed.",
+      "ErrorType": "Error",
+      "RuleExpressionType": "LambdaExpression",
+      "Expression": "1==1",
+      "Actions": {
+        "OnSuccess": {
+          "Name": "ReturnTrueIfCancellationRequestedAction",
+          "Context": {}
+        }
+      }
+    },
+    {
+      "RuleName": "TwoEqualsTwoRule",
+      "ErrorMessage": "One or more adjust rules failed.",
+      "ErrorType": "Error",
+      "RuleExpressionType": "LambdaExpression",
+      "Expression": "2==2",
+      "Actions": {
+        "OnSuccess": {
+          "Name": "ReturnTrueIfCancellationRequestedAction",
+          "Context": {}
+        }
+      }
+    }
+
+  ]
+}


### PR DESCRIPTION
#### Description:
This pull request adds unit tests to verify the correct handling of cancellation tokens in the `ExecuteAllRulesAsync` and `ExecuteActionWorkflowAsync` methods of the Rules Engine.

#### Changes:
1. **New Unit Tests:**
   - Added the test method `ExecuteAllRulesAsync_WithCancellationToken_CancelsProperly` to ensure the method respects the cancellation token and properly handles cancellation.
   - Added the test method `ExecuteActionWorkflowAsync_WithCancellationToken_CancelsProperly` to verify that executing a single rule with a cancellation token is handled correctly.
   - Both tests check that when the cancellation token is triggered, the appropriate exception (`TaskCanceledException`) is thrown.

2. **Custom Action Implementation:**
   - Implemented `ReturnTrueIfCancellationRequestedAction` class to simulate an action that can be cancelled.
   - The action method checks for cancellation and returns `true` if the cancellation is requested.

#### Test Details:
- The unit tests use short timeouts on the cancellation token to trigger cancellation quickly.
- They verify that the appropriate exception (`TaskCanceledException`) is thrown when cancellation is requested.
- Ensures other rules that do not require cancellation complete without exceptions.


#### Quick Tip:
In the library implementation, we are not breaking the loop if the cancellation is requested. This decision is left to the users of the library, allowing them to decide whether to stop execution using the cancellation flag or by throwing an exception. This approach provides more control to the final user, enabling them to complete tasks gracefully before breaking the process if they choose to.

Please review the changes and let me know if any adjustments are needed. 

Thank you!