### PR TITLE
 Switch from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/benchmark/RulesEngineBenchmark/Program.cs
+++ b/benchmark/RulesEngineBenchmark/Program.cs
@@ -3,7 +3,7 @@
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
-using Newtonsoft.Json;
+using System.Text.Json;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
@@ -34,7 +34,7 @@ namespace RulesEngineBenchmark
             }
 
             var fileData = File.ReadAllText(files[0]);
-            workflow = JsonConvert.DeserializeObject<List<Workflow>>(fileData);
+            workflow = JsonSerializer.Deserialize<List<Workflow>>(fileData);
 
             rulesEngine = new RulesEngine.RulesEngine(workflow.ToArray(), new ReSettings {
                 EnableFormattedErrorMessage = false,

--- a/demo/DemoApp/EFDemo.cs
+++ b/demo/DemoApp/EFDemo.cs
@@ -2,8 +2,7 @@
 //  Licensed under the MIT License.
 
 using DemoApp.EFDataExample;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
@@ -24,11 +23,9 @@ namespace DemoApp
             var orderInfo = "{\"totalOrders\": 5,\"recurringItems\": 2}";
             var telemetryInfo = "{\"noOfVisitsPerMonth\": 10,\"percentageOfBuyingToVisit\": 15}";
 
-            var converter = new ExpandoObjectConverter();
-
-            dynamic input1 = JsonConvert.DeserializeObject<ExpandoObject>(basicInfo, converter);
-            dynamic input2 = JsonConvert.DeserializeObject<ExpandoObject>(orderInfo, converter);
-            dynamic input3 = JsonConvert.DeserializeObject<ExpandoObject>(telemetryInfo, converter);
+            dynamic input1 = JsonSerializer.Deserialize<ExpandoObject>(basicInfo);
+            dynamic input2 = JsonSerializer.Deserialize<ExpandoObject>(orderInfo);
+            dynamic input3 = JsonSerializer.Deserialize<ExpandoObject>(telemetryInfo);
 
             var inputs = new dynamic[]
                 {
@@ -42,7 +39,7 @@ namespace DemoApp
                 throw new Exception("Rules not found.");
 
             var fileData = File.ReadAllText(files[0]);
-            var workflow = JsonConvert.DeserializeObject<List<Workflow>>(fileData);
+            var workflow = JsonSerializer.Deserialize<List<Workflow>>(fileData);
 
             RulesEngineDemoContext db = new RulesEngineDemoContext();
             if (db.Database.EnsureCreated())

--- a/demo/DemoApp/JSON.cs
+++ b/demo/DemoApp/JSON.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
@@ -35,7 +34,7 @@ namespace DemoApp.Demos
             }
 
             var fileData = await File.ReadAllTextAsync(files[0], ct);
-            var workflow = JsonConvert.DeserializeObject<Workflow[]>(fileData);
+            var workflow = JsonSerializer.Deserialize<Workflow[]>(fileData);
 
             var bre = new RulesEngine.RulesEngine(workflow, null);
 

--- a/demo/DemoApp/JSONDemo.cs
+++ b/demo/DemoApp/JSONDemo.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
@@ -21,11 +20,9 @@ namespace DemoApp
             var orderInfo = "{\"totalOrders\": 5,\"recurringItems\": 2}";
             var telemetryInfo = "{\"noOfVisitsPerMonth\": 10,\"percentageOfBuyingToVisit\": 15}";
 
-            var converter = new ExpandoObjectConverter();
-
-            dynamic input1 = JsonConvert.DeserializeObject<ExpandoObject>(basicInfo, converter);
-            dynamic input2 = JsonConvert.DeserializeObject<ExpandoObject>(orderInfo, converter);
-            dynamic input3 = JsonConvert.DeserializeObject<ExpandoObject>(telemetryInfo, converter);
+            dynamic input1 = JsonSerializer.Deserialize<ExpandoObject>(basicInfo);
+            dynamic input2 = JsonSerializer.Deserialize<ExpandoObject>(orderInfo);
+            dynamic input3 = JsonSerializer.Deserialize<ExpandoObject>(telemetryInfo);
 
             var inputs = new dynamic[]
                 {
@@ -39,7 +36,7 @@ namespace DemoApp
                 throw new Exception("Rules not found.");
 
             var fileData = File.ReadAllText(files[0]);
-            var workflow = JsonConvert.DeserializeObject<List<Workflow>>(fileData);
+            var workflow = JsonSerializer.Deserialize<List<Workflow>>(fileData);
 
             var bre = new RulesEngine.RulesEngine(workflow.ToArray(), null);
 

--- a/demo/DemoApp/MultipleWorkflows.cs
+++ b/demo/DemoApp/MultipleWorkflows.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
 using RulesEngine.Extensions;
 using RulesEngine.Models;
 using System;

--- a/demo/DemoApp/NestedInput.cs
+++ b/demo/DemoApp/NestedInput.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using RulesEngine.Extensions;
 using RulesEngine.Models;
 using System;
@@ -54,7 +54,7 @@ namespace DemoApp.Demos
                 throw new Exception("Rules not found.");
             
             var fileData = await File.ReadAllTextAsync(files[0], ct);
-            var Workflows = JsonConvert.DeserializeObject<List<Workflow>>(fileData);
+            var Workflows = JsonSerializer.Deserialize<List<Workflow>>(fileData);
 
             var bre = new RulesEngine.RulesEngine(Workflows.ToArray(), null);
 

--- a/demo/DemoApp/NestedInputDemo.cs
+++ b/demo/DemoApp/NestedInputDemo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using RulesEngine.Extensions;
 using RulesEngine.Models;
 using System;
@@ -49,7 +49,7 @@ namespace DemoApp
             }
 
             var fileData = File.ReadAllText(files[0]);
-            var Workflows = JsonConvert.DeserializeObject<List<Workflow>>(fileData);
+            var Workflows = JsonSerializer.Deserialize<List<Workflow>>(fileData);
 
             var bre = new RulesEngine.RulesEngine(Workflows.ToArray(), null);
             foreach (var workflow in Workflows)

--- a/demo/DemoApp/RulesEngineContext.cs
+++ b/demo/DemoApp/RulesEngineContext.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Newtonsoft.Json;
+using System.Text.Json;
 using RulesEngine.Models;
 
 namespace DemoApp.Demos
@@ -47,14 +47,14 @@ namespace DemoApp.Demos
                     c => c);
 
                 entity.Property(b => b.Properties).HasConversion(
-                    v => JsonConvert.SerializeObject(v),
-                    v => JsonConvert.DeserializeObject<Dictionary<string, object>>(v))
+                    v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
+                    v => JsonSerializer.Deserialize<Dictionary<string, object>>(v, JsonSerializerOptions.Default))
                 .Metadata
                 .SetValueComparer(valueComparer);
 
                 entity.Property(p => p.Actions).HasConversion(
-                    v => JsonConvert.SerializeObject(v),
-                    v => JsonConvert.DeserializeObject<RuleActions>(v));
+                    v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
+                    v => JsonSerializer.Deserialize<RuleActions>(v, JsonSerializerOptions.Default));
 
                 entity.Ignore(b => b.WorkflowsToInject);
             });

--- a/src/RulesEngine/Actions/ActionContext.cs
+++ b/src/RulesEngine/Actions/ActionContext.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
@@ -34,7 +34,7 @@ namespace RulesEngine.Actions
                         value = kv.Value.ToString();
                         break;
                     default:
-                        value = JsonConvert.SerializeObject(kv.Value);
+                        value = JsonSerializer.Serialize(kv.Value);
                         break;
 
                 }
@@ -71,7 +71,7 @@ namespace RulesEngine.Actions
                 {
                     return (T)Convert.ChangeType(_context[name], typeof(T));
                 }
-                return JsonConvert.DeserializeObject<T>(_context[name]);
+                return JsonSerializer.Deserialize<T>(_context[name]);
             }
             catch (KeyNotFoundException)
             {

--- a/src/RulesEngine/Models/Rule.cs
+++ b/src/RulesEngine/Models/Rule.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -33,7 +32,7 @@ namespace RulesEngine.Models
         /// </summary>
         public bool Enabled { get; set; } = true;
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public RuleExpressionType RuleExpressionType { get; set; } = RuleExpressionType.LambdaExpression;
         public IEnumerable<string> WorkflowsToInject { get; set; }
         public IEnumerable<Rule> Rules { get; set; }

--- a/src/RulesEngine/Models/Workflow.cs
+++ b/src/RulesEngine/Models/Workflow.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="FastExpressionCompiler" Version="4.2.0" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
+++ b/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
@@ -9,7 +9,6 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
     <PackageReference Include="xunit" Version="2.6.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
#### Why the Change?

1. **Performance:** `System.Text.Json` is faster and uses less memory.
2. **Built-in:** It's part of .NET Core and .NET 5+, so fewer external dependencies.
3. **Security:** Better default security settings.
4. **Future-proof:** Regular updates from the .NET team.

#### What’s Different?

- **Serialization:**
  - **Before:** `JsonConvert.SerializeObject(myObject)`
  - **After:** `JsonSerializer.Serialize(myObject)`

- **Deserialization:**
  - **Before:** `JsonConvert.DeserializeObject<MyClass>(jsonString)`
  - **After:** `JsonSerializer.Deserialize<MyClass>(jsonString)`

- **Enum Conversion:**
  - **Before:** `[JsonConverter(typeof(StringEnumConverter))]`
  - **After:** `[JsonConverter(typeof(JsonStringEnumConverter))]`

#### Other Details
- **Code Coverage, CodeQL, and Unit Tests:** All passing.

#### Things to Watch Out For

- **Feature Differences:** Some advanced `Newtonsoft.Json` features might not have direct equivalents.
- **Configuration:** Default behaviors might differ (e.g., property naming). Adjust `JsonSerializerOptions` as needed.