### PR TITLE
Add JSON Element Handling for System.Text.Json Compatibility

### DIFF
--- a/demo/DemoApp/CustomParameterName.cs
+++ b/demo/DemoApp/CustomParameterName.cs
@@ -21,7 +21,7 @@ public class CustomParameterName : IDemo
                         RuleName = "MatchesFabrikam",
                         SuccessEvent = "does match",
                         ErrorMessage = "does not match",
-                        Expression = @"myValue.Value1 == ""Fabrikam\"""
+                        Expression = @"myValue.Value1 == ""Fabrikam"""
                     }
                 }
             }
@@ -29,7 +29,7 @@ public class CustomParameterName : IDemo
 
         var bre = new RulesEngine.RulesEngine(workflows);
 
-        var rp = new RuleParameter[] {new("myValue", new {Value1 = "Fabrikam"})};
+        var rp = new RuleParameter[] { new("myValue", new { Value1 = "Fabrikam" }) };
 
         var ret = await bre.ExecuteAllRulesAsync("my_workflow", cancellationToken, rp);
 

--- a/demo/DemoApp/EFDemo.cs
+++ b/demo/DemoApp/EFDemo.cs
@@ -38,7 +38,7 @@ public class EFDemo : IDemo
         }
 
         var fileData = await File.ReadAllTextAsync(files[0], cancellationToken);
-        var workflow = JsonSerializer.Deserialize<List<Workflow>>(fileData);
+        var workflow = JsonSerializer.Deserialize<List<Workflow>>(fileData)!;
 
         var db = new RulesEngineDemoContext();
         if (await db.Database.EnsureCreatedAsync(cancellationToken))
@@ -66,3 +66,4 @@ public class EFDemo : IDemo
         Console.WriteLine(discountOffered);
     }
 }
+

--- a/demo/DemoApp/UseFastExpressionCompiler.cs
+++ b/demo/DemoApp/UseFastExpressionCompiler.cs
@@ -44,8 +44,7 @@ public class UseFastExpressionCompiler : IDemo
 
         var bre = new RulesEngine.RulesEngine(worflow, reSettingsWithCustomTypes);
 
-        var ret = await bre.ExecuteAllRulesAsync("UseFastExpressionCompilerTest", cancellationToken, appData,
-            cancellationToken);
+        var ret = await bre.ExecuteAllRulesAsync("UseFastExpressionCompilerTest", cancellationToken, appData);
 
         if (ret is {Count: > 0})
         {

--- a/src/RulesEngine/HelperFunctions/JsonElementExtensions.cs
+++ b/src/RulesEngine/HelperFunctions/JsonElementExtensions.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Dynamic;
 using System.Text.Json;
 
@@ -33,26 +30,32 @@ namespace RulesEngine.HelperFunctions
                     return element.GetString();
 
                 case JsonValueKind.Number:
-                    if (element.TryGetInt32(out var intValue))
-                    {
-                        return intValue;
-                    }
-                    if (element.TryGetInt64(out var longValue))
-                    {
-                        return longValue;
-                    }
-
-                    return element.GetDecimal();
+                    return GetNumberValue(element);
 
                 case JsonValueKind.True:
                 case JsonValueKind.False:
                     return element.GetBoolean();
 
-                case JsonValueKind.Undefined:
                 case JsonValueKind.Null:
+                    return null;
+
                 default:
                     return null;
             }
+        }
+
+        private static object GetNumberValue(JsonElement element)
+        {
+            if (element.TryGetInt64(out var longValue))
+            {
+                return longValue;
+            }
+            if (element.TryGetDouble(out var doubleValue))
+            {
+                return doubleValue;
+            }
+
+            return element.GetDecimal();
         }
     }
 }

--- a/src/RulesEngine/HelperFunctions/JsonElementExtensions.cs
+++ b/src/RulesEngine/HelperFunctions/JsonElementExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Text.Json;
+
+namespace RulesEngine.HelperFunctions
+{
+    public static class JsonElementExtensions
+    {
+        public static dynamic ToExpandoObject(this JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    var expandoObject = new ExpandoObject() as IDictionary<string, object>;
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        expandoObject[property.Name] = property.Value.ToExpandoObject();
+                    }
+                    return expandoObject;
+
+                case JsonValueKind.Array:
+                    var list = new List<object>();
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        list.Add(item.ToExpandoObject());
+                    }
+                    return list;
+
+                case JsonValueKind.String:
+                    return element.GetString();
+
+                case JsonValueKind.Number:
+                    if (element.TryGetInt32(out var intValue))
+                    {
+                        return intValue;
+                    }
+                    if (element.TryGetInt64(out var longValue))
+                    {
+                        return longValue;
+                    }
+
+                    return element.GetDecimal();
+
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    return element.GetBoolean();
+
+                case JsonValueKind.Undefined:
+                case JsonValueKind.Null:
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -47,16 +47,17 @@ namespace RulesEngine.HelperFunctions
                 foreach (var expando in (IDictionary<string, object>)input)
                 {
                     Type value;
-                    if (expando.Value is IList)
+                    if (expando.Value is IList list)
                     {
-                        if (((IList)expando.Value).Count == 0)
+                        if (list.Count == 0)
+                        {
                             value = typeof(List<object>);
+                        }
                         else
                         {
-                            var internalType = CreateAbstractClassType(((IList)expando.Value)[0]);
-                            value = new List<object>().Cast(internalType).ToList(internalType).GetType();
+                            var internalType = CreateAbstractClassType(list[0]);
+                            value = typeof(List<>).MakeGenericType(internalType);
                         }
-
                     }
                     else
                     {
@@ -72,6 +73,11 @@ namespace RulesEngine.HelperFunctions
 
         public static object CreateObject(Type type, dynamic input)
         {
+            if (input is JsonElement inputElement)
+            {
+                return CreateObject(type, inputElement.ToExpandoObject());
+            }
+
             if (!(input is ExpandoObject))
             {
                 return Convert.ChangeType(input, type);
@@ -106,7 +112,7 @@ namespace RulesEngine.HelperFunctions
                     }
                     else if (expando.Value is JsonElement expandoElement)
                     {
-                        val = expandoElement.ToExpandoObject();
+                        val = CreateObject(propInfo.PropertyType, expandoElement);
                     }
                     else
                     {

--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -30,7 +30,7 @@ namespace RulesEngine.HelperFunctions
             List<DynamicProperty> props = new List<DynamicProperty>();
 
             if (input is JsonElement jsonElement)
-            {jsonElement.ValueKind
+            {
                 input = jsonElement.ToExpandoObject();
             }
             if (input == null)

--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
+using System.Text.Json;
 
 namespace RulesEngine.HelperFunctions
 {
@@ -28,6 +29,10 @@ namespace RulesEngine.HelperFunctions
         {
             List<DynamicProperty> props = new List<DynamicProperty>();
 
+            if (input is JsonElement jsonElement)
+            {jsonElement.ValueKind
+                input = jsonElement.ToExpandoObject();
+            }
             if (input == null)
             {
                 return typeof(object);
@@ -99,6 +104,10 @@ namespace RulesEngine.HelperFunctions
                         };
                         val = newList;
                     }
+                    else if (expando.Value is JsonElement expandoElement)
+                    {
+                        val = expandoElement.ToExpandoObject();
+                    }
                     else
                     {
                         val = expando.Value;
@@ -124,6 +133,4 @@ namespace RulesEngine.HelperFunctions
             return genericMethod.Invoke(null, new[] { self }) as IList;
         }
     }
-
-
 }

--- a/test/RulesEngine.UnitTest/JsonElementExtensionsTests.cs
+++ b/test/RulesEngine.UnitTest/JsonElementExtensionsTests.cs
@@ -67,7 +67,7 @@ public class JsonElementExtensionsTests
         var document = JsonDocument.Parse(jsonString);
         var expando = document.RootElement.ToExpandoObject();
 
-        Assert.Equal(12345.6789m, expando);
+        Assert.Equal(12345.6789, expando);
     }
 
     [Fact]

--- a/test/RulesEngine.UnitTest/JsonElementExtensionsTests.cs
+++ b/test/RulesEngine.UnitTest/JsonElementExtensionsTests.cs
@@ -1,0 +1,111 @@
+﻿using RulesEngine.HelperFunctions;
+using System.Text.Json;
+using Xunit;
+
+namespace RulesEngine.UnitTest;
+
+public class JsonElementExtensionsTests
+{
+    [Fact]
+    public void TestObjectConversion()
+    {
+        var jsonString = @"{""name"":""John"", ""age"":30, ""isStudent"":false}";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Equal("John", expando.name);
+        Assert.Equal(30, expando.age);
+        Assert.False(expando.isStudent);
+    }
+
+    [Fact]
+    public void TestArrayConversion()
+    {
+        var jsonString = @"[""apple"", ""banana"", ""cherry""]";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Equal("apple", expando[0]);
+        Assert.Equal("banana", expando[1]);
+        Assert.Equal("cherry", expando[2]);
+    }
+
+    [Fact]
+    public void TestStringConversion()
+    {
+        var jsonString = @"""Hello, World!""";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Equal("Hello, World!", expando);
+    }
+
+    [Fact]
+    public void TestNumberConversion_Int()
+    {
+        var jsonString = "42";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Equal(42, expando);
+    }
+
+    [Fact]
+    public void TestNumberConversion_Long()
+    {
+        var jsonString = "9223372036854775807";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Equal(9223372036854775807L, expando);
+    }
+
+    [Fact]
+    public void TestNumberConversion_Decimal()
+    {
+        const string jsonString = "12345.6789";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Equal(12345.6789m, expando);
+    }
+
+    [Fact]
+    public void TestBooleanConversion_True()
+    {
+        const string jsonString = "true";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.True(expando);
+    }
+
+    [Fact]
+    public void TestBooleanConversion_False()
+    {
+        const string jsonString = "false";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.False(expando);
+    }
+
+    [Fact]
+    public void TestNullConversion()
+    {
+        const string jsonString = "null";
+        var document = JsonDocument.Parse(jsonString);
+        var expando = document.RootElement.ToExpandoObject();
+
+        Assert.Null(expando);
+    }
+
+    [Fact]
+    public void TestUndefinedConversion()
+    {
+        JsonElement undefinedElement = default;
+        var expando = undefinedElement.ToExpandoObject();
+
+        Assert.Null(expando);
+    }
+}

--- a/test/RulesEngine.UnitTest/UtilsTests.cs
+++ b/test/RulesEngine.UnitTest/UtilsTests.cs
@@ -157,9 +157,9 @@ namespace RulesEngine.UnitTest
             Assert.Equal("John", result.name);
 
             var scores = (List<object>)result["scores"];
-            Assert.Equal(100l, scores[0]);
+            Assert.Equal(100L, scores[0]);
             Assert.Equal(95.7, scores[1]);
-            Assert.Equal(85l, scores[2]);
+            Assert.Equal(85L, scores[2]);
         }
     }
 }

--- a/test/RulesEngine.UnitTest/UtilsTests.cs
+++ b/test/RulesEngine.UnitTest/UtilsTests.cs
@@ -106,11 +106,9 @@ namespace RulesEngine.UnitTest
         public void CreateAbstractClassType_WithJsonElement_ShouldConvertToExpandoObject()
         {
             const string jsonString = @"{""name"":""John"", ""age"":30, ""isStudent"":false}";
-            var document = JsonDocument.Parse(jsonString);
-            var jsonElement = document.RootElement;
+            var document = JsonSerializer.Deserialize<ExpandoObject>(jsonString);
 
-            var type = Utils.CreateAbstractClassType(jsonElement);
-
+            var type = Utils.CreateAbstractClassType(document);
             var propertyNames = type.GetProperties().Select(p => p.Name).ToArray();
 
             Assert.Contains("name", propertyNames);
@@ -122,12 +120,10 @@ namespace RulesEngine.UnitTest
         public void CreateObject_WithJsonElement_ShouldConvertToExpandoObject()
         {
             var jsonString = @"{""name"":""John"", ""age"":30, ""isStudent"":false}";
-            var document = JsonDocument.Parse(jsonString);
-            var jsonElement = document.RootElement;
-            var expando = jsonElement.ToExpandoObject();
+            var document = JsonSerializer.Deserialize<ExpandoObject>(jsonString);
 
-            Type type = Utils.CreateAbstractClassType(expando);
-            var result = Utils.CreateObject(type, expando);
+            var type = Utils.CreateAbstractClassType(document);
+            dynamic result = Utils.CreateObject(type, document);
 
             Assert.Equal("John", result.name);
             Assert.Equal(30, result.age);
@@ -138,12 +134,10 @@ namespace RulesEngine.UnitTest
         public void CreateObject_WithJsonElementNested_ShouldConvertToExpandoObject()
         {
             var jsonString = @"{""name"":""John"", ""details"":{""age"":30, ""isStudent"":false}}";
-            var document = JsonDocument.Parse(jsonString);
-            var jsonElement = document.RootElement;
-            var expando = jsonElement.ToExpandoObject();
+            var document = JsonSerializer.Deserialize<ExpandoObject>(jsonString);
 
-            Type type = Utils.CreateAbstractClassType(expando);
-            var result = Utils.CreateObject(type, expando);
+            var type = Utils.CreateAbstractClassType(document);
+            dynamic result = Utils.CreateObject(type, document);
 
             Assert.Equal("John", result.name);
             Assert.Equal(30, result.details.age);
@@ -153,20 +147,19 @@ namespace RulesEngine.UnitTest
         [Fact]
         public void CreateObject_WithJsonElementArray_ShouldConvertToExpandoObject()
         {
-            const string jsonString = @"{""name"":""John"", ""scores"":[100, 95, 85]}";
-            var document = JsonDocument.Parse(jsonString);
-            var jsonElement = document.RootElement;
-            var expando = jsonElement.ToExpandoObject();
+            const string jsonString = @"{""name"":""John"", ""scores"":[100, 95.7, 85]}";
+            var document = JsonSerializer.Deserialize<ExpandoObject>(jsonString);
 
-            var type = Utils.CreateAbstractClassType(expando);
-            var result = Utils.CreateObject(type, expando);
+
+            var type = Utils.CreateAbstractClassType(document);
+            dynamic result = Utils.CreateObject(type, document);
 
             Assert.Equal("John", result.name);
 
-            var scores = (List<int>)result["scores"];
-            Assert.Equal(100, scores[0]);
-            Assert.Equal(95, scores[1]);
-            Assert.Equal(85, scores[2]);
+            var scores = (List<object>)result["scores"];
+            Assert.Equal(100l, scores[0]);
+            Assert.Equal(95.7, scores[1]);
+            Assert.Equal(85l, scores[2]);
         }
     }
 }

--- a/test/RulesEngine.UnitTest/UtilsTests.cs
+++ b/test/RulesEngine.UnitTest/UtilsTests.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
+using System.Linq;
+using System.Text.Json;
 using Xunit;
 
 namespace RulesEngine.UnitTest
@@ -22,7 +24,6 @@ namespace RulesEngine.UnitTest
     [ExcludeFromCodeCoverage]
     public class UtilsTests
     {
-
         [Fact]
         public void GetTypedObject_dynamicObject()
         {
@@ -75,7 +76,6 @@ namespace RulesEngine.UnitTest
             Assert.NotNull(typedobj.Test);
         }
 
-
         [Fact]
         public void CreateObject_dynamicObject()
         {
@@ -100,9 +100,73 @@ namespace RulesEngine.UnitTest
             Type type = Utils.CreateAbstractClassType(obj);
             Assert.NotEqual(typeof(ExpandoObject), type);
             Assert.NotNull(type.GetProperty("Test"));
-
         }
 
+        [Fact]
+        public void CreateAbstractClassType_WithJsonElement_ShouldConvertToExpandoObject()
+        {
+            const string jsonString = @"{""name"":""John"", ""age"":30, ""isStudent"":false}";
+            var document = JsonDocument.Parse(jsonString);
+            var jsonElement = document.RootElement;
 
+            var type = Utils.CreateAbstractClassType(jsonElement);
+
+            var propertyNames = type.GetProperties().Select(p => p.Name).ToArray();
+
+            Assert.Contains("name", propertyNames);
+            Assert.Contains("age", propertyNames);
+            Assert.Contains("isStudent", propertyNames);
+        }
+
+        [Fact]
+        public void CreateObject_WithJsonElement_ShouldConvertToExpandoObject()
+        {
+            var jsonString = @"{""name"":""John"", ""age"":30, ""isStudent"":false}";
+            var document = JsonDocument.Parse(jsonString);
+            var jsonElement = document.RootElement;
+            var expando = jsonElement.ToExpandoObject();
+
+            Type type = Utils.CreateAbstractClassType(expando);
+            var result = Utils.CreateObject(type, expando);
+
+            Assert.Equal("John", result.name);
+            Assert.Equal(30, result.age);
+            Assert.False(result.isStudent);
+        }
+
+        [Fact]
+        public void CreateObject_WithJsonElementNested_ShouldConvertToExpandoObject()
+        {
+            var jsonString = @"{""name"":""John"", ""details"":{""age"":30, ""isStudent"":false}}";
+            var document = JsonDocument.Parse(jsonString);
+            var jsonElement = document.RootElement;
+            var expando = jsonElement.ToExpandoObject();
+
+            Type type = Utils.CreateAbstractClassType(expando);
+            var result = Utils.CreateObject(type, expando);
+
+            Assert.Equal("John", result.name);
+            Assert.Equal(30, result.details.age);
+            Assert.False(result.details.isStudent);
+        }
+
+        [Fact]
+        public void CreateObject_WithJsonElementArray_ShouldConvertToExpandoObject()
+        {
+            const string jsonString = @"{""name"":""John"", ""scores"":[100, 95, 85]}";
+            var document = JsonDocument.Parse(jsonString);
+            var jsonElement = document.RootElement;
+            var expando = jsonElement.ToExpandoObject();
+
+            var type = Utils.CreateAbstractClassType(expando);
+            var result = Utils.CreateObject(type, expando);
+
+            Assert.Equal("John", result.name);
+
+            var scores = (List<int>)result["scores"];
+            Assert.Equal(100, scores[0]);
+            Assert.Equal(95, scores[1]);
+            Assert.Equal(85, scores[2]);
+        }
     }
 }


### PR DESCRIPTION
**Reason for Change:**
The primary reason for this change is the difference in how `System.Text.Json` handles `ExpandoObject` compared to `Newtonsoft.Json`. When using `System.Text.Json`, properties within an `ExpandoObject` are deserialized as `JsonElement` rather than their respective .NET types (e.g., string, int). This behavior can lead to issues where the compiler cannot work with the dynamically deserialized properties directly.

**Examples:**

**Newtonsoft.Json Example:**
When you deserialize JSON to a dynamic object with Newtonsoft.Json, it converts the JSON properties to their corresponding .NET types directly:

```csharp
dynamic config = JsonConvert.DeserializeObject<ExpandoObject>(json);
Console.WriteLine(config.name);  // Outputs: John
```

**System.Text.Json Example:**
In contrast, System.Text.Json does not convert properties to their .NET types but keeps them as `JsonElement`:

```csharp
dynamic config = JsonSerializer.Deserialize<ExpandoObject>(json);
Console.WriteLine(config.name.GetType());  // Outputs: System.Text.Json.JsonElement
```

This difference means you can't directly access or manipulate the values without additional conversion steps. As a result, handling `JsonElement` requires converting them into more manageable types, such as `ExpandoObject`.

**Changes Made:**

1. **In `CreateAbstractClassType` Method:**
    - Added code to convert `JsonElement` to `ExpandoObject`:

    ```csharp
    if (input is JsonElement jsonElement)
    {
        input = jsonElement.ToExpandoObject();
    }
    ```

2. **In `CreateObject` Method:**
    - Added code to handle `JsonElement` within expando properties:

    ```csharp
    else if (expando.Value is JsonElement expandoElement)
    {
        val = expandoElement.ToExpandoObject();
    }
    ```

**Tests Added:**

1. **CreateAbstractClassType_WithJsonElement_ShouldConvertToExpandoObject**
    - Ensures that `JsonElement` input is correctly converted and that the dynamic type has the expected properties.

2. **CreateObject_WithJsonElement_ShouldConvertToExpandoObject**
    - Ensures that `CreateObject` correctly handles `JsonElement` and converts it to an `ExpandoObject`.

3. **CreateObject_WithJsonElementNested_ShouldConvertToExpandoObject**
    - Verifies correct handling of nested JSON objects.

4. **CreateObject_WithJsonElementArray_ShouldConvertToExpandoObject**
    - Ensures JSON arrays within objects are properly converted.

This pull request resolves issues caused by the serialization behavior of `System.Text.Json`, allowing the dynamic type creation and object creation methods to work seamlessly with JSON data serialized by `System.Text.Json`. 

References:
- [Makolyte](https://makolyte.com/csharp-deserialize-json-to-dynamic-object/)