### PR TITLE
Preserve Original ExpandoObject and Implement TryGetPropertyValue in RuleParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+### Changelog
+
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## [6.0.1]
+
+### Added
+- **Preserve Original Object**: Introduced `OriginalValue` property in `RuleParameter` to preserve the original `Expando` without converting its type.
+- **TryGetPropertyValue Method**: Implemented `TryGetPropertyValue` to safely access properties, returning a boolean indicating success and setting the out parameter to the property value or `null` if not found.
+
+### Fixed
+- **Data Integrity Issue**: Ensured both the original dynamic object and the typed version are accessible, maintaining data integrity throughout the workflow execution.
+
+For more details, refer to the [GitHub issue](https://github.com/asulwer/RulesEngine/issues/53).
+
 ## [6.0.0]
 
 - **GitHub Actions**

--- a/src/RulesEngine/Models/RuleParameter.cs
+++ b/src/RulesEngine/Models/RuleParameter.cs
@@ -3,23 +3,23 @@
 
 using RulesEngine.HelperFunctions;
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Linq.Dynamic.Core;
 using System.Linq.Expressions;
 
 namespace RulesEngine.Models
 {
-    [ExcludeFromCodeCoverage]
     public class RuleParameter
     {
         public RuleParameter(string name, object value)
         {
+            OriginalValue = value;
             Value = Utils.GetTypedObject(value);
             Init(name, Value?.GetType());
         }
 
-       
-        internal RuleParameter(string name, Type type,object value = null)
+        internal RuleParameter(string name, Type type, object value = null)
         {
+            OriginalValue = value;
             Value = Utils.GetTypedObject(value);
             Init(name, type);
         }
@@ -27,6 +27,7 @@ namespace RulesEngine.Models
         public Type Type { get; private set; }
         public string Name { get; private set; }
         public object Value { get; private set; }
+        public object OriginalValue { get; private set; }
         public ParameterExpression ParameterExpression { get; private set; }
 
         private void Init(string name, Type type)
@@ -40,9 +41,26 @@ namespace RulesEngine.Models
         {
             var typedValue = Utils.GetTypedObject(value);
             var type = typedValue?.GetType() ?? typeof(T);
-            return new RuleParameter(name,type,value);
+            return new RuleParameter(name, type, value);
         }
 
+        public bool TryGetPropertyValue<T>(string propertyName, out T value)
+        {
+            value = default;
 
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                return false;
+            }
+
+            if (Value is DynamicClass dc)
+            {
+                var result = dc.GetDynamicPropertyValue<T>(propertyName);
+                value = result;
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/RulesEngine/Models/RuleParameter.cs
+++ b/src/RulesEngine/Models/RuleParameter.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using FastExpressionCompiler;
 using RulesEngine.HelperFunctions;
 using System;
+using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Linq.Expressions;
 
@@ -53,7 +55,7 @@ namespace RulesEngine.Models
                 return false;
             }
 
-            if (Value is DynamicClass dc)
+            if (Value is DynamicClass dc && dc.GetDynamicMemberNames().Contains(propertyName))
             {
                 var result = dc.GetDynamicPropertyValue<T>(propertyName);
                 value = result;

--- a/test/RulesEngine.UnitTest/RuleParameterTest.cs
+++ b/test/RulesEngine.UnitTest/RuleParameterTest.cs
@@ -34,7 +34,7 @@ namespace RulesEngine.Tests
             var ruleParameter = new RuleParameter("data", input);
 
             // Act
-            var result = ruleParameter.TryGetPropertyValue<int>("nonExistentProperty", out var value);
+            var result = ruleParameter.TryGetPropertyValue<int?>("nonExistentProperty", out var value);
 
             // Assert
             Assert.False(result);
@@ -54,7 +54,7 @@ namespace RulesEngine.Tests
 
             // Assert
             Assert.True(result);
-            Assert.Equal(default, value);
+            Assert.Equal(input.count, value);
         }
 
         [Fact]

--- a/test/RulesEngine.UnitTest/RuleParameterTest.cs
+++ b/test/RulesEngine.UnitTest/RuleParameterTest.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using RulesEngine.Models;
+using System.Dynamic;
+using Xunit;
+
+namespace RulesEngine.Tests
+{
+    public class RuleParameterTests
+    {
+        [Fact]
+        public void TryGetPropertyValue_WithNullPropertyName_ReturnsFalseAndNull()
+        {
+            // Arrange
+            dynamic input = new ExpandoObject();
+            input.count = 1;
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Act
+            var result = ruleParameter.TryGetPropertyValue<int>(null, out var value);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void TryGetPropertyValue_WithNonExistentPropertyName_ReturnsFalseAndNull()
+        {
+            // Arrange
+            dynamic input = new ExpandoObject();
+            input.count = 1;
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Act
+            var result = ruleParameter.TryGetPropertyValue<int>("nonExistentProperty", out var value);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void TryGetPropertyValue_WithValidPropertyName_ReturnsTrueAndCorrectValue()
+        {
+            // Arrange
+            dynamic input = new ExpandoObject();
+            input.count = 1;
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Act
+            var result = ruleParameter.TryGetPropertyValue<int>("count", out var value);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(default, value);
+        }
+
+        [Fact]
+        public void Constructor_SetsOriginalValueCorrectly_WithExpandoObject()
+        {
+            // Arrange
+            dynamic input = new ExpandoObject();
+            input.count = 1;
+
+            // Act
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Assert
+            Assert.Equal(input, ruleParameter.OriginalValue);
+        }
+
+        [Fact]
+        public void Constructor_SetsOriginalValueCorrectly_WithPrimitiveType()
+        {
+            // Arrange
+            int input = 5;
+
+            // Act
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Assert
+            Assert.Equal(input, ruleParameter.OriginalValue);
+        }
+
+        [Fact]
+        public void Constructor_SetsOriginalValueCorrectly_WithCustomObject()
+        {
+            // Arrange
+            var input = new { Name = "Test", Value = 10 };
+
+            // Act
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Assert
+            Assert.Equal(input, ruleParameter.OriginalValue);
+        }
+    }
+}


### PR DESCRIPTION
**Summary of Changes**

1. **Added `OriginalValue` Property**:
   - Preserves the original `ExpandoObject` without converting its type.

2. **Implemented `TryGetPropertyValue` Method**:
   - Safely accesses properties, returning a boolean indicating success and setting the out parameter to the property value or `null` if not found.

3. **Created Unit Tests**:
   - Tests for `TryGetPropertyValue` behavior and ensuring `OriginalValue` is correctly set in the constructor.

**Reason for Changes**

The issue involved the `RuleParameter` class transforming `ExpandoObject` into a strongly-typed object, causing a loss of the expected type when casting back. The changes ensure that both the original dynamic object and the typed version are accessible, maintaining data integrity throughout the workflow execution.