### PR TITLE
Fix how empty arrays are handled by expressions

### DIFF
--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using RulesEngine.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -9,6 +8,8 @@ using System.Dynamic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
 using System.Text.Json;
+
+using RulesEngine.Models;
 
 namespace RulesEngine.HelperFunctions
 {

--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -109,10 +109,6 @@ namespace RulesEngine.HelperFunctions
                             var child = CreateObject(internalType, temp[i]);
                             newList.Add(child);
                         };
-                        if(newList.Count == 0)
-                        {
-                            newList = new List<Dictionary<string, ImplicitObject>>();
-                        }
                         val = newList;
                     }
                     else if (expando.Value is JsonElement expandoElement)

--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using RulesEngine.Models;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -51,7 +52,7 @@ namespace RulesEngine.HelperFunctions
                     {
                         if (list.Count == 0)
                         {
-                            value = typeof(List<object>);
+                            value = typeof(List<Dictionary<string, ImplicitObject>>);
                         }
                         else
                         {
@@ -108,6 +109,10 @@ namespace RulesEngine.HelperFunctions
                             var child = CreateObject(internalType, temp[i]);
                             newList.Add(child);
                         };
+                        if(newList.Count == 0)
+                        {
+                            newList = new List<Dictionary<string, ImplicitObject>>();
+                        }
                         val = newList;
                     }
                     else if (expando.Value is JsonElement expandoElement)

--- a/src/RulesEngine/Models/ImplicitObject.cs
+++ b/src/RulesEngine/Models/ImplicitObject.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace RulesEngine.Models
+{
+    public class ImplicitObject
+    {
+        #region Implicit Operators
+
+        public static implicit operator ImplicitObject(string value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(int value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(int? value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(decimal value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(decimal? value)
+        {
+            return default;
+        }
+
+        #endregion
+
+    }
+}

--- a/src/RulesEngine/Models/ImplicitObject.cs
+++ b/src/RulesEngine/Models/ImplicitObject.cs
@@ -7,6 +7,26 @@ namespace RulesEngine.Models
     {
         #region Implicit Operators
 
+        public static implicit operator ImplicitObject(bool value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(bool? value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(char value)
+        {
+            return default;
+        }
+
+        public static implicit operator ImplicitObject(char? value)
+        {
+            return default;
+        }
+
         public static implicit operator ImplicitObject(string value)
         {
             return default;


### PR DESCRIPTION
This PR fixes an issue with how empty arrays, provided via an expando object, are handled by the rules engine. System.Linq is checking the data type of the expected underlying object before comparing the contents of the actual object. This is causing issues when empty arrays are provided in json bodies, and these get converted to a `List<object>`. If you have a rule expression that looks something like `widgets.Any(a == 3)`, and `widgets` is an empty array, the expression parser in System.Linq would experience an issue comparing an `object` to an integer. 

To fix this issue, this PR creates a new class named `ImplicitObject` which contains implicit operators for every logical data type that can be passed in from a json object. 

Run the following code:

```csharp
using System.Collections;
using System.Dynamic;
using System.Text.Json;

using Newtonsoft.Json.Converters;

using RulesEngine.Models;

string payload = "{\"prop\":\"someString\",\"someInt\":3,\"nest\":{\"code\":\"bar\",\"foo\":true},\"emptyArray\":[],\"populatedArray\":[{\"a\":2,\"subArray\":[{\"c\":4}]}]}";

Workflow[] workflow = [
    new() {
        WorkflowName = "Workflow",
        Rules = [
            new() {
                RuleName = "someInt check",
                Expression = "someInt > 1",
                RuleExpressionType = RuleExpressionType.LambdaExpression
            },
            new() {
                RuleName = "empty array",
                Expression = "not emptyArray.Any(a == 'a')",
                RuleExpressionType = RuleExpressionType.LambdaExpression
            },
            new() {
                RuleName = "populatedArray with subArray not match",
                Expression = "populatedArray.Any(subArray.Any(c == 4))",
                RuleExpressionType = RuleExpressionType.LambdaExpression
            },
            new() {
                RuleName = "check prop",
                Expression = "prop = \"someString\"",
                RuleExpressionType = RuleExpressionType.LambdaExpression
            },
            new() {
                RuleName = "check nested code",
                Expression = "nest.code eq \"bar\" and nest.foo == true",
                RuleExpressionType = RuleExpressionType.LambdaExpression
            }
        ]
    }
];

var rulesEngine = new RulesEngine.RulesEngine(workflow, new() {
    IsExpressionCaseSensitive = false,
    CustomTypes = new[] {
        typeof(IEnumerable)
    }
});

var target = Newtonsoft.Json.JsonConvert.DeserializeObject<ExpandoObject>(payload, new ExpandoObjectConverter())!;

CancellationTokenSource cancellationTokenSource = new();
List<RuleResultTree> results = await rulesEngine.ExecuteAllRulesAsync("Workflow", cancellationTokenSource.Token, target);

Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(target, new JsonSerializerOptions { WriteIndented = true }));
Console.WriteLine();

foreach(var result in results) {
    Console.WriteLine($"\t{result.IsSuccess}\t{result.Rule.Expression}");
    if(result.ExceptionMessage.Length > 0) Console.WriteLine($"\t\t\t{result.ExceptionMessage}");
}
```