### PR TITLE
version updated

### DIFF
--- a/src/RulesEngine/Actions/ActionBase.cs
+++ b/src/RulesEngine/Actions/ActionBase.cs
@@ -4,7 +4,6 @@
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace RulesEngine.Actions

--- a/src/RulesEngine/Actions/EvaluateRuleAction.cs
+++ b/src/RulesEngine/Actions/EvaluateRuleAction.cs
@@ -3,10 +3,8 @@
 
 using RulesEngine.ExpressionBuilders;
 using RulesEngine.Models;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace RulesEngine.Actions

--- a/src/RulesEngine/Actions/ExpressionOutputAction.cs
+++ b/src/RulesEngine/Actions/ExpressionOutputAction.cs
@@ -3,7 +3,6 @@
 
 using RulesEngine.ExpressionBuilders;
 using RulesEngine.Models;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace RulesEngine.Actions

--- a/src/RulesEngine/Exceptions/ExpressionParserException.cs
+++ b/src/RulesEngine/Exceptions/ExpressionParserException.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace RulesEngine.Exceptions
 {

--- a/src/RulesEngine/Exceptions/RuleException.cs
+++ b/src/RulesEngine/Exceptions/RuleException.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace RulesEngine.Exceptions
 {

--- a/src/RulesEngine/Exceptions/ScopedParamException.cs
+++ b/src/RulesEngine/Exceptions/ScopedParamException.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace RulesEngine.Exceptions
 {

--- a/src/RulesEngine/ExpressionBuilders/LambdaExpressionBuilder.cs
+++ b/src/RulesEngine/ExpressionBuilders/LambdaExpressionBuilder.cs
@@ -6,7 +6,6 @@ using RulesEngine.HelperFunctions;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Dynamic.Core.Exceptions;
 using System.Linq.Expressions;
 

--- a/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
+++ b/src/RulesEngine/ExpressionBuilders/RuleExpressionParser.cs
@@ -2,7 +2,6 @@
 //  Licensed under the MIT License.
 
 using FastExpressionCompiler;
-using RulesEngine.HelperFunctions;
 using RulesEngine.Models;
 using System;
 using System.Collections.Generic;

--- a/src/RulesEngine/Extensions/EnumerableExtensions.cs
+++ b/src/RulesEngine/Extensions/EnumerableExtensions.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RulesEngine.Extensions
 {

--- a/src/RulesEngine/Extensions/ListofRuleResultTreeExtension.cs
+++ b/src/RulesEngine/Extensions/ListofRuleResultTreeExtension.cs
@@ -5,7 +5,6 @@ using RulesEngine.Models;
 using System.Collections.Generic;
 using System.Linq;
 
-
 namespace RulesEngine.Extensions
 {
     public static class ListofRuleResultTreeExtension

--- a/src/RulesEngine/HelperFunctions/ExpressionUtils.cs
+++ b/src/RulesEngine/HelperFunctions/ExpressionUtils.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Linq;
 
 namespace RulesEngine.HelperFunctions

--- a/src/RulesEngine/HelperFunctions/Helpers.cs
+++ b/src/RulesEngine/HelperFunctions/Helpers.cs
@@ -6,7 +6,6 @@ using RulesEngine.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace RulesEngine.HelperFunctions
 {

--- a/src/RulesEngine/HelperFunctions/MemCache.cs
+++ b/src/RulesEngine/HelperFunctions/MemCache.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 

--- a/src/RulesEngine/Models/ImplicitObject.cs
+++ b/src/RulesEngine/Models/ImplicitObject.cs
@@ -4,16 +4,11 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace RulesEngine.Models
 {
     [ExcludeFromCodeCoverage]
     public class ImplicitObject
     {
-
-        #region Implicit Operators
-
         public static implicit operator ImplicitObject(bool value) => default;
 
         public static implicit operator ImplicitObject(bool? value) => default;
@@ -35,8 +30,5 @@ namespace RulesEngine.Models
         public static implicit operator ImplicitObject(float value) => default;
 
         public static implicit operator ImplicitObject(float? value) => default;
-
-        #endregion
-
     }
 }

--- a/src/RulesEngine/Models/RuleExpressionParameter.cs
+++ b/src/RulesEngine/Models/RuleExpressionParameter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 

--- a/src/RulesEngine/Models/RuleParameter.cs
+++ b/src/RulesEngine/Models/RuleParameter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using FastExpressionCompiler;
 using RulesEngine.HelperFunctions;
 using System;
 using System.Linq;

--- a/src/RulesEngine/Models/RuleResultTree.cs
+++ b/src/RulesEngine/Models/RuleResultTree.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using RulesEngine.HelperFunctions;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/RulesEngine/RulesEngine.cs
+++ b/src/RulesEngine/RulesEngine.cs
@@ -459,10 +459,12 @@ namespace RulesEngine
 
             if (model != null)
             {
-                using var jDoc = JsonSerializer.SerializeToDocument(model);
-                errorMessage = jDoc.RootElement.TryGetProperty(propertyName, out var jElement) ? 
-                    errorMessage.Replace($"$({property})", jElement.GetRawText() ?? $"({property})") : 
-                    errorMessage.Replace($"$({property})", $"({property})");
+                using (var jDoc = JsonSerializer.SerializeToDocument(model))
+                {
+                    errorMessage = jDoc.RootElement.TryGetProperty(propertyName, out var jElement) ?
+                        errorMessage.Replace($"$({property})", jElement.GetRawText() ?? $"({property})") :
+                        errorMessage.Replace($"$({property})", $"({property})");
+                }
             }
 
             return errorMessage;

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>disable</Nullable>
-    <Version>6.0.5</Version>
+    <Version>6.0.6</Version>
     <PackageId>RulesEngineEx</PackageId>
 	<PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/asulwer/RulesEngine</PackageProjectUrl>


### PR DESCRIPTION
1. RulesEngine.cs - UpdateErrorMessage, wrapped block in using statement
2. removed unused using statements
3. updated RulesEngine version to include changes from issue [#75](https://github.com/asulwer/RulesEngine/issues/75)
4. **targeting NetStandard2.0 AND 2.1**
