### PR TITLE
Fix less than/greater than operators in empty arrays

### DIFF
--- a/src/RulesEngine/Models/ImplicitObject.cs
+++ b/src/RulesEngine/Models/ImplicitObject.cs
@@ -2,33 +2,61 @@
 // Licensed under the MIT License.
 // https://github.com/asulwer/RulesEngine/issues/75
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace RulesEngine.Models
 {
     [ExcludeFromCodeCoverage]
-    public class ImplicitObject
+    public class ImplicitObject : IEquatable<ImplicitObject>
     {
-        public static implicit operator ImplicitObject(bool value) => default;
+        public static implicit operator ImplicitObject(bool _) => default;
 
-        public static implicit operator ImplicitObject(bool? value) => default;
+        public static implicit operator ImplicitObject(bool? _) => default;
 
-        public static implicit operator ImplicitObject(char value) => default;
+        public static implicit operator ImplicitObject(char _) => default;
 
-        public static implicit operator ImplicitObject(char? value) => default;
+        public static implicit operator ImplicitObject(char? _) => default;
 
-        public static implicit operator ImplicitObject(string value) => default;
+        public static implicit operator ImplicitObject(string _) => default;
 
-        public static implicit operator ImplicitObject(int value) => default;
+        public static implicit operator ImplicitObject(int _) => default;
 
-        public static implicit operator ImplicitObject(int? value) => default;
+        public static implicit operator ImplicitObject(int? _) => default;
 
-        public static implicit operator ImplicitObject(decimal value) => default;
+        public static implicit operator ImplicitObject(decimal _) => default;
 
-        public static implicit operator ImplicitObject(decimal? value) => default;
+        public static implicit operator ImplicitObject(decimal? _) => default;
 
-        public static implicit operator ImplicitObject(float value) => default;
+        public static implicit operator ImplicitObject(float _) => default;
 
-        public static implicit operator ImplicitObject(float? value) => default;
+        public static implicit operator ImplicitObject(float? _) => default;
+
+        public static bool operator <(ImplicitObject l, ImplicitObject r) => default;
+
+        public static bool operator >(ImplicitObject l, ImplicitObject r) => default;
+
+        public static bool operator <=(ImplicitObject l, ImplicitObject r) => default;
+
+        public static bool operator >=(ImplicitObject l, ImplicitObject r) => default;
+
+        public static bool operator ==(ImplicitObject l, ImplicitObject r) => default;
+
+        public static bool operator !=(ImplicitObject l, ImplicitObject r) => default;
+
+        public bool Equals(ImplicitObject other)
+        {
+            return default;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return default;
+        }
+
+        public override int GetHashCode()
+        {
+            return default;
+        }
     }
 }

--- a/test/RulesEngine.UnitTest/EmptyArrayTest.cs
+++ b/test/RulesEngine.UnitTest/EmptyArrayTest.cs
@@ -25,9 +25,32 @@ namespace RulesEngine.UnitTest
                     WorkflowName = "Workflow",
                     Rules = [
                         new() {
-                            RuleName = "empty array",
-                            Expression = "not things.Any(a == 3)",
-                            RuleExpressionType = RuleExpressionType.LambdaExpression
+                            RuleName = "equal string",
+                            Expression = "not things.Any(a == \"widget\")"
+                        },
+                        new() {
+                            RuleName = "equal integer",
+                            Expression = "not things.Any(a == 3)"
+                        },
+                        new() {
+                            RuleName = "not equal integer",
+                            Expression = "not things.Any(a != 3)"
+                        },
+                        new() {
+                            RuleName = "greater than integer",
+                            Expression = "not things.Any(a > 3)"
+                        },
+                        new() {
+                            RuleName = "less than integer",
+                            Expression = "not things.Any(a < 3)"
+                        },
+                        new() {
+                            RuleName = "greater than equal to integer",
+                            Expression = "not things.Any(a >= 3)"
+                        },
+                        new() {
+                            RuleName = "less than equal to integer",
+                            Expression = "not things.Any(a <= 3)"
                         }
                     ]
                 }
@@ -50,12 +73,14 @@ namespace RulesEngine.UnitTest
             CancellationTokenSource cancellationTokenSource = new();
             List<RuleResultTree> results = await rulesEngine.ExecuteAllRulesAsync("Workflow", cancellationTokenSource.Token, target);
 
-            Assert.Single(results);
+            Assert.True(results.TrueForAll(r => r.IsSuccess));
 
-            var result = results[0];
+            foreach (var result in results)
+            {
+                Assert.Equal(result.ExceptionMessage, string.Empty);
+                Assert.True(result.IsSuccess);
+            }
 
-            Assert.Equal(result.ExceptionMessage, string.Empty);
-            Assert.True(result.IsSuccess);
 
         }
 

--- a/test/RulesEngine.UnitTest/NestedRulesTest.cs
+++ b/test/RulesEngine.UnitTest/NestedRulesTest.cs
@@ -44,14 +44,14 @@ namespace RulesEngine.UnitTest
                 Assert.All(andResults,
                     c => {
                         Assert.Equal(c.IsSuccess, c.ChildResults.Last().IsSuccess);
-                        Assert.Single(c.ChildResults.Where(d => c.IsSuccess == d.IsSuccess));
+                        Assert.Single(c.ChildResults, d => c.IsSuccess == d.IsSuccess);
                         Assert.True(c.ChildResults.SkipLast(1).All(d => d.IsSuccess == true));
                     });
 
                 Assert.All(orResults,
                     c => {
                         Assert.Equal(c.IsSuccess, c.ChildResults.Last().IsSuccess);
-                        Assert.Single(c.ChildResults.Where(d => c.IsSuccess == d.IsSuccess));
+                        Assert.Single(c.ChildResults, d => c.IsSuccess == d.IsSuccess);
                         Assert.True(c.ChildResults.SkipLast(1).All(d => d.IsSuccess == false));
                     });
             }
@@ -240,14 +240,14 @@ namespace RulesEngine.UnitTest
                 Assert.All(andResults,
                     c => {
                         Assert.Equal(c.IsSuccess, c.ChildResults.Last().IsSuccess);
-                        Assert.Single(c.ChildResults.Where(d => c.IsSuccess == d.IsSuccess));
+                        Assert.Single(c.ChildResults, d => c.IsSuccess == d.IsSuccess);
                         Assert.True(c.ChildResults.SkipLast(1).All(d => d.IsSuccess == true));
                     });
 
                 Assert.All(orResults,
                     c => {
                         Assert.Equal(c.IsSuccess, c.ChildResults.Last().IsSuccess);
-                        Assert.Single(c.ChildResults.Where(d => c.IsSuccess == d.IsSuccess));
+                        Assert.Single(c.ChildResults, d => c.IsSuccess == d.IsSuccess);
                         Assert.True(c.ChildResults.SkipLast(1).All(d => d.IsSuccess == false));
                     });
             }


### PR DESCRIPTION
This PR fixes the usage of less than and greater than when comparing numeric values in empty arrays

Fixes https://github.com/asulwer/RulesEngine/issues/90