### PR TITLE
Fix AmbiguousMatchException 

### DIFF
--- a/src/RulesEngine/HelperFunctions/Utils.cs
+++ b/src/RulesEngine/HelperFunctions/Utils.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Linq.Dynamic.Core;
+using System.Reflection;
 using System.Text.Json;
 
 using RulesEngine.Models;
@@ -86,7 +87,7 @@ namespace RulesEngine.HelperFunctions
             }
             object obj = Activator.CreateInstance(type);
 
-            var typeProps = type.GetProperties().ToDictionary(c => c.Name);
+            var typeProps = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance).ToDictionary(c => c.Name);
 
             foreach (var expando in (IDictionary<string, object>)input)
             {
@@ -109,7 +110,7 @@ namespace RulesEngine.HelperFunctions
                         {
                             var child = CreateObject(internalType, temp[i]);
                             newList.Add(child);
-                        };
+                        }
                         val = newList;
                     }
                     else if (expando.Value is JsonElement expandoElement)

--- a/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
+++ b/test/RulesEngine.UnitTest/BusinessRuleEngineTest.cs
@@ -541,7 +541,7 @@ namespace RulesEngine.UnitTest
         [InlineData("rules11.json")]
         public async Task RulesEngineWithGlobalParam_RunsSuccessfully(string ruleFileName)
         {
-
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
             var re = GetRulesEngine(ruleFileName, new ReSettings() { });
 
             var input1 = new[] {

--- a/test/RulesEngine.UnitTest/RuleParameterTest.cs
+++ b/test/RulesEngine.UnitTest/RuleParameterTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using RulesEngine.Models;
+using System.Collections.Generic;
 using System.Dynamic;
 using Xunit;
 
@@ -89,6 +90,22 @@ namespace RulesEngine.Tests
         {
             // Arrange
             var input = new { Name = "Test", Value = 10 };
+
+            // Act
+            var ruleParameter = new RuleParameter("data", input);
+
+            // Assert
+            Assert.Equal(input, ruleParameter.OriginalValue);
+        }
+
+        [Fact]
+        public void Constructor_SetsOriginalValueCorrectly_WithExpandoObject_WithItemKey()
+        {
+            // Arrange
+            var input = new ExpandoObject();
+            ((IDictionary<string, object>)input)["Item"] = "hello";
+            ((IDictionary<string, object>)input)["L"] = 1000;
+            ((IDictionary<string, object>)input)["W"] = 500;
 
             // Act
             var ruleParameter = new RuleParameter("data", input);

--- a/test/RulesEngine.UnitTest/UtilsTests.cs
+++ b/test/RulesEngine.UnitTest/UtilsTests.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Linq;
+using System.Linq.Dynamic.Core;
+using System.Reflection;
 using System.Text.Json;
 using Xunit;
 
@@ -36,6 +38,22 @@ namespace RulesEngine.UnitTest
             object typedobj = Utils.GetTypedObject(obj);
             Assert.IsNotType<ExpandoObject>(typedobj);
             Assert.NotNull(typedobj.GetType().GetProperty("Test"));
+        }
+
+        [Fact]
+        public void GetTypedObject_Anonymous_dynamicObject()
+        {
+            dynamic obj = new ExpandoObject();
+            ((IDictionary<string, object>)obj)["Item"] = "hello";
+            ((IDictionary<string, object>)obj)["L"] = 1000;
+            ((IDictionary<string, object>)obj)["W"] = 500;
+
+            object typedobj = Utils.GetTypedObject(obj);
+            Assert.IsNotType<ExpandoObject>(typedobj);
+            Assert.NotNull(typedobj.GetType().GetProperty("L"));
+            Assert.NotNull(typedobj.GetType().GetProperty("W"));
+            Assert.NotNull(typedobj.GetType().GetProperty("Item", BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance));
+            Assert.Throws<AmbiguousMatchException>(() => typedobj.GetType().GetProperty("Item"));
         }
 
         [Fact]
@@ -89,7 +107,6 @@ namespace RulesEngine.UnitTest
             object newObj = Utils.CreateObject(typeof(TestClass), obj);
             Assert.IsNotType<ExpandoObject>(newObj);
             Assert.NotNull(newObj.GetType().GetProperty("Test"));
-
         }
 
         [Fact]
@@ -182,7 +199,6 @@ namespace RulesEngine.UnitTest
 
             Assert.IsType<List<Dictionary<string, ImplicitObject>>>(result.things);
             Assert.Empty((List<Dictionary<string, ImplicitObject>>)result.things);
-            
         }
     }
 }


### PR DESCRIPTION
Fix AmbiguousMatchException when dynamic object used like dictionary with 'Item' key.