### PR TITLE
Add net10 support

### DIFF
--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 8.x
+        dotnet-version: 10.x
     
     - name: Install dependencies
       run: dotnet restore RulesEngine.sln

--- a/.github/workflows/dotnetcore-release.yml
+++ b/.github/workflows/dotnetcore-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/benchmark/RulesEngineBenchmark/RulesEngineBenchmark.csproj
+++ b/benchmark/RulesEngineBenchmark/RulesEngineBenchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 	<IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/demo/DemoApp/DemoApp.csproj
+++ b/demo/DemoApp/DemoApp.csproj
@@ -2,14 +2,14 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<StartupObject>DemoApp.Program</StartupObject>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.12" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.12" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.0",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/RulesEngine/Actions/ActionBase.cs
+++ b/src/RulesEngine/Actions/ActionBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 //  Licensed under the MIT License.
 
 using RulesEngine.Models;
@@ -21,8 +21,8 @@ namespace RulesEngine.Actions
             {
                 if (!reSettings.IgnoreException && reSettings.EnableExceptionAsErrorMessage)
                     result.Exception = new Exception($"Exception while executing {GetType().Name}: {ex.Message}", ex);
-                else if(!reSettings.IgnoreException && !reSettings.EnableExceptionAsErrorMessage)
-                    throw ex;
+                else if (!reSettings.IgnoreException && !reSettings.EnableExceptionAsErrorMessage)
+                    throw;
             }
             finally
             {

--- a/src/RulesEngine/Extensions/EnumerableExtensions.cs
+++ b/src/RulesEngine/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -14,10 +14,9 @@ namespace RulesEngine.Extensions
             return enumerable ?? Enumerable.Empty<T>();
         }
 
-        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source,Func<TSource, TKey> keySelector)
+#if NETSTANDARD2_0_OR_GREATER
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            
-
             var seenKeys = new HashSet<TKey>();
 
             foreach (var element in source)
@@ -28,5 +27,6 @@ namespace RulesEngine.Extensions
                 }
             }
         }
+#endif
     }
 }

--- a/src/RulesEngine/RuleCompiler.cs
+++ b/src/RulesEngine/RuleCompiler.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using RulesEngine.Exceptions;
 using RulesEngine.ExpressionBuilders;
+#if NETSTANDARD2_0_OR_GREATER
 using RulesEngine.Extensions;
+#endif
 using RulesEngine.HelperFunctions;
 using RulesEngine.Models;
 using System;
@@ -52,18 +54,17 @@ namespace RulesEngine
         {
             if (rule == null)
             {
-                var ex =  new ArgumentNullException(nameof(rule));
+                var ex = new ArgumentNullException(nameof(rule));
                 throw ex;
             }
             try
             {
                 var globalParamExp = globalParams.Value;
-                var extendedRuleParams = ruleParams.Concat(globalParamExp.Select(c => new RuleParameter(c.ParameterExpression.Name,c.ParameterExpression.Type)))
+                var extendedRuleParams = ruleParams.Concat(globalParamExp.Select(c => new RuleParameter(c.ParameterExpression.Name, c.ParameterExpression.Type)))
                                                    .DistinctBy(x => x.Name).ToArray();
                 var ruleExpression = GetDelegateForRule(rule, extendedRuleParams);
-                
 
-                return GetWrappedRuleFunc(rule,ruleExpression,ruleParams,globalParamExp);
+                return GetWrappedRuleFunc(rule, ruleExpression, ruleParams, globalParamExp);
             }
             catch (Exception ex)
             {
@@ -71,8 +72,6 @@ namespace RulesEngine
                 return Helpers.ToRuleExceptionResult(_reSettings, rule, new RuleException(message, ex));
             }
         }
-
-
 
         /// <summary>
         /// Gets the expression for rule.
@@ -89,7 +88,7 @@ namespace RulesEngine
                                                .ToArray();
 
             RuleFunc<RuleResultTree> ruleFn;
-            
+
             if (Enum.TryParse(rule.Operator, out ExpressionType nestedOperator) && nestedOperators.Contains(nestedOperator) &&
                 rule.Rules != null && rule.Rules.Any())
             {
@@ -103,9 +102,9 @@ namespace RulesEngine
             return GetWrappedRuleFunc(rule, ruleFn, ruleParams, scopedParamList);
         }
 
-        internal RuleExpressionParameter[] GetRuleExpressionParameters(RuleExpressionType ruleExpressionType,IEnumerable<ScopedParam> localParams, RuleParameter[] ruleParams)
+        internal RuleExpressionParameter[] GetRuleExpressionParameters(RuleExpressionType ruleExpressionType, IEnumerable<ScopedParam> localParams, RuleParameter[] ruleParams)
         {
-            if(!_reSettings.EnableScopedParams)
+            if (!_reSettings.EnableScopedParams)
             {
                 return new RuleExpressionParameter[] { };
             }
@@ -136,7 +135,7 @@ namespace RulesEngine
 
                         parametersArray = parameters.ToArray();
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         var message = $"{ex.Message}, in ScopedParam: {lp.Name}";
                         throw new RuleException(message);
@@ -144,7 +143,6 @@ namespace RulesEngine
                 }
             }
             return ruleExpParams.ToArray();
-
         }
 
         /// <summary>
@@ -190,23 +188,22 @@ namespace RulesEngine
             };
         }
 
-
-        private (bool isSuccess ,IEnumerable<RuleResultTree> result) ApplyOperation(RuleParameter[] paramArray,IEnumerable<RuleFunc<RuleResultTree>> ruleFuncList, ExpressionType operation)
+        private (bool isSuccess, IEnumerable<RuleResultTree> result) ApplyOperation(RuleParameter[] paramArray, IEnumerable<RuleFunc<RuleResultTree>> ruleFuncList, ExpressionType operation)
         {
             if (ruleFuncList?.Any() != true)
             {
-                return (false,new List<RuleResultTree>());
+                return (false, new List<RuleResultTree>());
             }
 
             var resultList = new List<RuleResultTree>();
             var isSuccess = false;
 
-            if(operation == ExpressionType.And || operation == ExpressionType.AndAlso)
+            if (operation == ExpressionType.And || operation == ExpressionType.AndAlso)
             {
                 isSuccess = true;
             }
 
-            foreach(var ruleFunc in ruleFuncList)
+            foreach (var ruleFunc in ruleFuncList)
             {
                 var ruleResult = ruleFunc(paramArray);
                 resultList.Add(ruleResult);
@@ -215,7 +212,7 @@ namespace RulesEngine
                     case ExpressionType.And:
                     case ExpressionType.AndAlso:
                         isSuccess = isSuccess && ruleResult.IsSuccess;
-                        if(_reSettings.NestedRuleExecutionMode ==  NestedRuleExecutionMode.Performance && isSuccess == false)
+                        if (_reSettings.NestedRuleExecutionMode == NestedRuleExecutionMode.Performance && isSuccess == false)
                         {
                             return (isSuccess, resultList);
                         }
@@ -230,24 +227,22 @@ namespace RulesEngine
                         }
                         break;
                 }
-                
             }
             return (isSuccess, resultList);
         }
 
-        internal Func<object[],Dictionary<string,object>> CompileScopedParams(RuleExpressionType ruleExpressionType, RuleParameter[] ruleParameters,RuleExpressionParameter[] ruleExpParams)
+        internal Func<object[], Dictionary<string, object>> CompileScopedParams(RuleExpressionType ruleExpressionType, RuleParameter[] ruleParameters, RuleExpressionParameter[] ruleExpParams)
         {
             return GetExpressionBuilder(ruleExpressionType).CompileScopedParams(ruleParameters, ruleExpParams);
-
         }
 
-        private RuleFunc<RuleResultTree> GetWrappedRuleFunc(Rule rule, RuleFunc<RuleResultTree> ruleFunc,RuleParameter[] ruleParameters,RuleExpressionParameter[] ruleExpParams)
+        private RuleFunc<RuleResultTree> GetWrappedRuleFunc(Rule rule, RuleFunc<RuleResultTree> ruleFunc, RuleParameter[] ruleParameters, RuleExpressionParameter[] ruleExpParams)
         {
-            if(ruleExpParams.Length == 0)
+            if (ruleExpParams.Length == 0)
             {
                 return ruleFunc;
             }
-            var paramDelegate = CompileScopedParams(rule.RuleExpressionType,ruleParameters, ruleExpParams);
+            var paramDelegate = CompileScopedParams(rule.RuleExpressionType, ruleParameters, ruleExpParams);
 
             return (ruleParams) => {
                 var inputs = ruleParams.Select(c => c.Value).ToArray();
@@ -257,13 +252,13 @@ namespace RulesEngine
                     var scopedParamsDict = paramDelegate(inputs);
                     scopedParams = scopedParamsDict.Select(c => new RuleParameter(c.Key, c.Value));
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     var message = $"Error while executing scoped params for rule `{rule.RuleName}` - {ex}";
                     var resultFn = Helpers.ToRuleExceptionResult(_reSettings, rule, new RuleException(message, ex));
                     return resultFn(ruleParams);
                 }
-               
+
                 var extendedInputs = ruleParams.Concat(scopedParams).DistinctBy(x => x.Name);
                 var result = ruleFunc(extendedInputs.ToArray());
                 return result;

--- a/src/RulesEngine/RulesEngine.csproj
+++ b/src/RulesEngine/RulesEngine.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <Nullable>disable</Nullable>
     <Version>6.0.14</Version>
     <PackageId>RulesEngineEx</PackageId>
-	<PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/asulwer/RulesEngine</PackageProjectUrl>
     <RepositoryUrl>https://github.com/asulwer/RulesEngine</RepositoryUrl>
     <Authors>Aaron Sulwer, Renan Pereira</Authors>
     <Description>Rules Engine is a package for abstracting business logic/rules/policies out of the system. This works in a very simple way by giving you an ability to put your rules in a store outside the core logic of the system thus ensuring that any change in rules doesn't affect the core system.</Description>
-	  <PackageReleaseNotes>https://github.com/asulwer/RulesEngine/blob/main/CHANGELOG.md</PackageReleaseNotes>
-	  <PackageTags>BRE, Rules Engine, Abstraction</PackageTags>
+    <PackageReleaseNotes>https://github.com/asulwer/RulesEngine/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <PackageTags>BRE, Rules Engine, Abstraction</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
@@ -24,24 +24,31 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <SignAssembly>True</SignAssembly>
-	<AssemblyOriginatorKeyFile>..\..\signing\RulesEngine-publicKey.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\..\signing\RulesEngine-publicKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>True</DelaySign>
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="FastExpressionCompiler" Version="5.3.0" />
-    <PackageReference Include="FluentValidation" Version="11.12.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.5" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="FluentValidation" Version="11.12.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="FluentValidation" Version="12.1.1" />
   </ItemGroup>
 
 </Project>

--- a/test/RulesEngine.UnitTest/NestedRulesTest.cs
+++ b/test/RulesEngine.UnitTest/NestedRulesTest.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using RulesEngine.Models;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
@@ -11,12 +12,45 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RulesEngine.UnitTest
 {
     [ExcludeFromCodeCoverage]
     public class NestedRulesTest
     {
+        private readonly ITestOutputHelper _output;
+
+        public NestedRulesTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+        private static void DebugOutput(ITestOutputHelper output, string workFlowName, List<RuleResultTree> result)
+        {
+            int r = 1;
+            output.WriteLine($"WF: {workFlowName}");
+            foreach (var ruleResult in result)
+            {
+                if (ruleResult.ActionResult != null)
+                {
+                    output.WriteLine($"{r}: {ruleResult.IsSuccess} {ruleResult.Rule.RuleName} - [{ruleResult.ActionResult.Output}]");
+                }
+
+                int c = 1;
+                if (ruleResult.ChildResults != null)
+                {
+                    foreach (var childrenResult in ruleResult.ChildResults)
+                    {
+                        if (childrenResult.ActionResult != null)
+                        {
+                            output.WriteLine($"\t{r}.{c++}: {childrenResult.IsSuccess} {childrenResult.Rule.RuleName} - [{childrenResult.ActionResult.Output}]");
+                        }
+                    }
+                }
+                r++;
+            }
+        }
+
         [Theory]
         [InlineData(NestedRuleExecutionMode.All)]
         [InlineData(NestedRuleExecutionMode.Performance)]
@@ -29,6 +63,8 @@ namespace RulesEngine.UnitTest
             input1.trueValue = true;
 
             List<RuleResultTree> result = await rulesEngine.ExecuteAllRulesAsync("NestedRulesTest", input1);
+            DebugOutput(_output, "NestedRulesTest", result);
+
             var andResults = result.Where(c => c.Rule.Operator == "And").ToList();
             var orResults = result.Where(c => c.Rule.Operator == "Or").ToList();
             Assert.All(andResults, c => Assert.False(c.IsSuccess));
@@ -67,6 +103,7 @@ namespace RulesEngine.UnitTest
             input1.trueValue = true;
 
             List<RuleResultTree> result = await rulesEngine.ExecuteAllRulesAsync("NestedRulesActionsTest", input1);
+            DebugOutput(_output, "NestedRulesActionsTest", result);
 
             Assert.False(result[0].IsSuccess);
             Assert.Equal(input1.trueValue, result[0].ActionResult.Output);
@@ -89,6 +126,7 @@ namespace RulesEngine.UnitTest
             input1.trueValue = true;
 
             List<RuleResultTree> result = await rulesEngine.ExecuteAllRulesAsync("NestedRulesActionsTest", input1);
+            DebugOutput(_output, "NestedRulesActionsTest", result);
 
             Assert.False(result[0].IsSuccess);
             Assert.Equal(input1.trueValue, result[0].ActionResult.Output);
@@ -227,13 +265,13 @@ namespace RulesEngine.UnitTest
             var result = await rulesEngine.ExecuteAllRulesAsync("NestedRulesTest", new[] { input1 });
             var andResults = result.Where(c => c.Rule.Operator == "And").ToList();
             var orResults = result.Where(c => c.Rule.Operator == "Or").ToList();
-            Assert.All(andResults,c => Assert.False(c.IsSuccess));
-            Assert.All(orResults,c => Assert.True(c.IsSuccess));
+            Assert.All(andResults, c => Assert.False(c.IsSuccess));
+            Assert.All(orResults, c => Assert.True(c.IsSuccess));
 
             if (mode == NestedRuleExecutionMode.All)
             {
-                Assert.All(andResults,c => Assert.Equal(c.Rule.Rules.Count(), c.ChildResults.Count()));
-                Assert.All(orResults,c => Assert.Equal(c.Rule.Rules.Count(), c.ChildResults.Count()));
+                Assert.All(andResults, c => Assert.Equal(c.Rule.Rules.Count(), c.ChildResults.Count()));
+                Assert.All(orResults, c => Assert.Equal(c.Rule.Rules.Count(), c.ChildResults.Count()));
             }
             else if (mode == NestedRuleExecutionMode.Performance)
             {

--- a/test/RulesEngine.UnitTest/ParameterNameChangeTest.cs
+++ b/test/RulesEngine.UnitTest/ParameterNameChangeTest.cs
@@ -3,11 +3,13 @@
 
 using RulesEngine.Models;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using static RulesEngine.UnitTest.RulesEngineTest;
 
 namespace RulesEngine.UnitTest
 {
@@ -38,6 +40,58 @@ namespace RulesEngine.UnitTest
             var pass_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_pass);
             // RuleParameter name DOES NOT MATCH expression, so should fail.
             var fail_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", input_fail);
+            Assert.True(pass_results.First().IsSuccess);
+            Assert.False(fail_results.First().IsSuccess);
+        }
+
+        [Fact]
+        public async Task AnotherParameterName_ReturnsExpectedResults()
+        {
+            var workflow = new Workflow() {
+                WorkflowName = "ParameterNameChangeWorkflow",
+                Rules = new List<Rule> {
+                        new() {
+                            RuleName = "ParameterNameChangeRule",
+                            Expression = "IsItem AND testParam.Qty > 0",
+                            RuleExpressionType = RuleExpressionType.LambdaExpression,
+                            Actions = new RuleActions {
+                                OnSuccess = new ActionInfo {
+                                    Name = "OutputExpression",
+                                    Context = new Dictionary<string, object> {{"expression", "testParam.Qty" } }
+                                }
+                            }
+                        },
+                    },
+                GlobalParams = new List<ScopedParam> {
+                        new() {Name = "isTest", Expression ="Regex.IsMatch(testParam.Item, \"^[tT]\\\\w+[tT]\\\\w*\") == true" },
+                        new() {Name = "isTestOrItem",  Expression ="Regex.IsMatch(testParam.Description, \"\\\\btest|\\\\bitem\", RegexOptions.IgnoreCase) == true" },
+                        new() {Name = "IsItem", Expression ="utils.CheckExists(String(testParam.Item)) == true OR (isTest AND isTestOrItem)" },
+                    }
+            };
+
+            var reSettings = new ReSettings {
+                CustomTypes = [
+                    typeof(System.Text.RegularExpressions.Regex),
+                    typeof(System.Text.RegularExpressions.RegexOptions),
+                    typeof(TestInstanceUtils),
+                    ]
+            };
+            var engine = new RulesEngine(reSettings);
+            engine.AddOrUpdateWorkflow(workflow);
+
+            dynamic dynamicTestParam = new ExpandoObject();
+            dynamicTestParam.Qty = 1;
+            dynamicTestParam.Item = "Test";
+            dynamicTestParam.Description = "Test Item";
+
+            var input_pass = new RuleParameter("testParam", dynamicTestParam);
+            var input_fail = new RuleParameter("SOME_OTHER_NAME", dynamicTestParam);
+            var utils = new RuleParameter("utils", new TestInstanceUtils());
+            var inputParams = new List<RuleParameter> { input_pass, utils };
+            // RuleParameter name matches expression, so should pass.
+            var pass_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", [.. inputParams]);
+            // RuleParameter name DOES NOT MATCH expression, so should fail.
+            var fail_results = await engine.ExecuteAllRulesAsync("ParameterNameChangeWorkflow", [input_fail, utils]);
             Assert.True(pass_results.First().IsSuccess);
             Assert.False(fail_results.First().IsSuccess);
         }

--- a/test/RulesEngine.UnitTest/RuleExpressionParserTests/RuleExpressionParserTests.cs
+++ b/test/RulesEngine.UnitTest/RuleExpressionParserTests/RuleExpressionParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using RulesEngine.ExpressionBuilders;
@@ -8,7 +8,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Xunit;
 
 namespace RulesEngine.UnitTest.RuleExpressionParserTests
@@ -16,11 +15,7 @@ namespace RulesEngine.UnitTest.RuleExpressionParserTests
     [ExcludeFromCodeCoverage]
     public class RuleExpressionParserTests
     {
-        public RuleExpressionParserTests() {
-
-
-        }
-
+        public RuleExpressionParserTests() { }
 
         [Fact]
         public void TestExpressionWithJObject()
@@ -38,9 +33,9 @@ namespace RulesEngine.UnitTest.RuleExpressionParserTests
 
             var value1 = ruleParser.Evaluate<object>("input.list[0].item3 == 1", new[] { new RuleParameter("input", input) });
             var value2 = ruleParser.Evaluate<object>("input.list[1].item1 == \"world\"", new[] { new RuleParameter("input", input) });
-            var value3= ruleParser.Evaluate<object>("string.Concat(input.list[0].item1, input.list[1].item1)", new[] { new RuleParameter("input", input) });
+            var value3 = ruleParser.Evaluate<object>("string.Concat(input.list[0].item1, input.list[1].item1)", new[] { new RuleParameter("input", input) });
 
-             Assert.Equal(true, value1);
+            Assert.Equal(true, value1);
             Assert.Equal(true, value2);
             Assert.Equal("helloworld", value3);
         }
@@ -51,7 +46,7 @@ namespace RulesEngine.UnitTest.RuleExpressionParserTests
             var board = new { NumberOfMembers = default(double?) };
 
             var parameters = new RuleParameter[] {
-                RuleParameter.Create("Board", board) 
+                RuleParameter.Create("Board", board)
             };
 
             var parser = new RuleExpressionParser();
@@ -74,7 +69,8 @@ namespace RulesEngine.UnitTest.RuleExpressionParserTests
 
         [Theory]
         [InlineData(false)]
-        public void TestExpressionWithDifferentCompilerSettings(bool fastExpressionEnabled){
+        public void TestExpressionWithDifferentCompilerSettings(bool fastExpressionEnabled)
+        {
             var ruleParser = new RuleExpressionParser(new Models.ReSettings() { UseFastExpressionCompiler = fastExpressionEnabled });
 
             decimal? d1 = null;
@@ -82,6 +78,4 @@ namespace RulesEngine.UnitTest.RuleExpressionParserTests
             Assert.False(result);
         }
     }
-    
-
 }

--- a/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
+++ b/test/RulesEngine.UnitTest/RulesEngine.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\signing\RulesEngine-publicKey.snk</AssemblyOriginatorKeyFile>
     <DelaySign>True</DelaySign>
@@ -8,15 +8,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/RulesEngine.UnitTest/TestData/rules11.json
+++ b/test/RulesEngine.UnitTest/TestData/rules11.json
@@ -24,7 +24,7 @@
           "Expression": "int.Parse(\u002215\u0022)"
         }
       ],
-      "Expression": "input1.Count \u003E= ruleCount \u0026\u0026 input1.Where(x =\u003E x.Value \u003E= threshold).Count() \u003E= ruleCount",
+      "Expression": "input1.Count >= ruleCount && input1.Where(x => x.Value >= threshold).Count() >= ruleCount",
       "Actions": null,
       "SuccessEvent": null
     },


### PR DESCRIPTION
This PR adds additional net8 and net10 target frameworks, and use net10 for build/test/release environment. 
Main changes:
* Add net8.0 and net10.0 TargetFrameworks
* Add Condition for FluentValidation in RulesEngine.csproj depends on TargetFramework
* Migrate csproj's to .NET10  and update nuget packages to latest versions.
